### PR TITLE
ubuntuのバージョンを14.10から15.04に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Docker file for knowledge
 
-FROM ubuntu:14.10
+FROM ubuntu:15.04
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y openjdk-8-jre-headless tomcat8 wget
 RUN rm -rf /var/lib/tomcat8/webapps/ROOT
 RUN wget -O /var/lib/tomcat8/webapps/ROOT.war https://github.com/support-project/knowledge/releases/download/v0.5.3/knowledge.war


### PR DESCRIPTION
14.10のサポートがきれてるため15.04にしてみました。
- 確認内容
  - ビルドが正常に終わること
  - ビルドしたコンテナでknowledgeを起動させて正常に動くこと
- 備考
  - パッケージインストール時にReadline(perl)のエラーがでるため  
    `ENV DEBIAN_FRONTEND=noninteractive`を追加しています

ご検討お願いいたします。
