### PR TITLE
use image tomcat:jre8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,21 @@
 # Dockerfile for Knowledge
 
-FROM debian:jessie-backports
+FROM tomcat:jre8
 
 # ==== dumb-init ====
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.0.0/dumb-init_1.0.0_amd64 \
       /usr/local/bin/dumb-init
 
 # ==== environment ====
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive \
-       apt-get install -y openjdk-8-jre-headless tomcat8 \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/tomcat8/webapps/ROOT \
+RUN rm -rf /usr/local/tomcat/webapps/ROOT \
   && update-ca-certificates -f \
   && chmod +x /usr/local/bin/dumb-init
-ENV CATALINA_HOME=/usr/share/tomcat8 \
-    CATALINA_BASE=/var/lib/tomcat8
 
 # ==== add Knowledge ====
 ADD https://github.com/support-project/knowledge/releases/download/v1.0.0/knowledge.war \
-      /var/lib/tomcat8/webapps/ROOT.war
+      /usr/local/tomcat/webapps/ROOT.war
 
 VOLUME [ "/root/.knowledge" ]
 EXPOSE 8080
 
-CMD [ "/usr/local/bin/dumb-init", "/usr/share/tomcat8/bin/catalina.sh", "run" ]
+CMD [ "/usr/local/bin/dumb-init", "/usr/local/tomcat/bin/catalina.sh", "run" ]


### PR DESCRIPTION
`FROM tomcat:jre8` になりました。
docker公式が提供しているtomcat8で、記述がスリムになりました。
