### PR TITLE
PostreSQLのvolumeが正しくマウントされない不具合を修正しました

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,5 @@ services:
             - POSTGRES_DB=knowledge_production
         volumes:
             #- ./volumes/initdb:/docker-entrypoint-initdb.d
-            - ./volumes/postgres:/var/lib/postgresql
+            - ./volumes/postgres/data:/var/lib/postgresql/data
         restart: always


### PR DESCRIPTION
こんにちは．いつも便利に活用させて頂いております．

docker-compose.yml で指定されているPostgreSQLのvolume指定が誤っており，
DBに格納されるデータが永続化されない不具合を修正しました．

## 課題
現在のコードでは，`volumes/postgres/data` 以下にファイルが一切作られず，コンテナ内にデータが保存されています．
そのため，コンテナ廃棄のタイミングで，Knowledgeのユーザ情報や投稿記事の情報が失われてしまいます．

## 対策
volumeの指定を修正し，正しいマウント先に`volumes/postgres/data`がマウントされるよう修正しました．

ご参考: 
https://github.com/docker-library/postgres/blob/913bc48bfdccab58c6c15f11841da5146e7bf968/9.6/Dockerfile#L62

以上です．マージをご検討ください．
